### PR TITLE
🛟 Arrumador: Configure standard tooling and fix CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,58 @@
+name: Autorelease
+
+on:
+  push:
+    branches: ["main", "master"]
+    tags: ["v*"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@v2
+
+      - name: Install
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changes == 'true' && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update generated code"
+          title: "chore: update generated code"
+          body: "This PR updates generated code."
+          branch: "chore/codegen-update"
+          base: ${{ github.head_ref || github.ref_name }}
+
+      - name: CI
+        run: mise run ci
+
+      - name: Build
+        if: startsWith(github.ref, 'refs/tags/')
+        run: go build -v -o ncgi .
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} ncgi --generate-notes

--- a/mise.toml
+++ b/mise.toml
@@ -1,37 +1,19 @@
 [tools]
 go = "1.23.0"
-golangci-lint = "1.61.0"
-actionlint = "1.7.1"
 python = "3.12.9"
-ruff = "0.9.9"
+"github:lucasew/workspaced" = "0.1.3"
 
 [tasks.install]
 description = "Install dependencies"
 run = "go mod download"
 
-[tasks."lint:golangci-lint"]
-description = "Run golangci-lint"
-run = "golangci-lint run"
-
-[tasks."lint:actionlint"]
-description = "Run actionlint"
-run = "actionlint"
-
-[tasks."lint:ruff"]
-description = "Run ruff"
-run = "ruff check"
-
 [tasks.lint]
 description = "Run all linters"
-depends = ["lint:*"]
-
-[tasks."fmt:go"]
-description = "Format Go code"
-run = "gofmt -w ."
+run = "workspaced codebase lint"
 
 [tasks.fmt]
 description = "Run all formatters"
-depends = ["fmt:*"]
+run = "workspaced codebase format"
 
 [tasks.test]
 description = "Run tests"


### PR DESCRIPTION
This PR configures standard tooling (`mise`, `workspaced`) and a robust CI workflow (`autorelease.yml`) for the `ncgi` repository.

### Changes
- Updated `mise.toml` to use `workspaced` (v0.1.3) via `github:` backend for `lint` and `fmt` tasks.
- Removed individual linter definitions (`golangci-lint`, `actionlint`, `ruff`) as they are managed by `workspaced`.
- Created `.github/workflows/autorelease.yml` following the required flow: Install -> Codegen -> PR -> CI -> Release -> Artifacts.
- Configured release steps to build `ncgi` binary from root and create GitHub release on tags.

### Verification
- Verified `mise run ci` executes successfully (lint and test).
- Verified `workspaced` installation via `mise`.
- Verified `codegen` task existence and correctness.

### Assumptions
- The repository name is `ncgi` and the main package is at the root.
- `workspaced` v0.1.3 is stable and suitable for this project.
- Release artifacts are only needed for tag events.

---
*PR created automatically by Jules for task [9506835136159025520](https://jules.google.com/task/9506835136159025520) started by @lucasew*