### PR TITLE
📝 Docs: Document error handling and subprocess lifecycle

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,10 @@ import (
 	"log"
 )
 
-// ReportError logs the error with metadata.
+// ReportError handles non-fatal errors through a centralized mechanism.
+// It ensures consistent logging and is the designated injection point
+// for external error monitoring systems (like Sentry) in the future.
+// It silently returns on nil errors to simplify call-site logic.
 func ReportError(err error, metadata map[string]interface{}) {
 	if err == nil {
 		return
@@ -17,7 +20,10 @@ func ReportError(err error, metadata map[string]interface{}) {
 	}
 }
 
-// ReportFatal logs the error and exits.
+// ReportFatal operates identically to ReportError but explicitly
+// halts the application via log.Fatal. It should only be used when
+// the application enters an unrecoverable state where continuing
+// operation would cause data corruption or meaningless behavior.
 func ReportFatal(err error, metadata map[string]interface{}) {
 	if err != nil {
 		ReportError(err, metadata)

--- a/main.go
+++ b/main.go
@@ -21,9 +21,19 @@ func init() {
 	_ = spew.Config
 }
 
-var bufsize int
-var script string
-var port int
+var (
+	// bufsize dictates the chunk size (default 64KB) for streaming stdout
+	// from the executed CGI scripts back to the HTTP response.
+	bufsize int
+
+	// script points to the path of the executable/file that the HTTP server
+	// will trigger as its backend handler for incoming requests.
+	script string
+
+	// port defines the listening port for the HTTP server. A value of 0 signals
+	// the OS to automatically assign a free port, avoiding collisions.
+	port int
+)
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -56,6 +66,14 @@ func main() {
 	}
 }
 
+// handleSubprocess manages the lifecycle of external commands passed to ncgi.
+// It serves two crucial non-obvious roles:
+//  1. If no command is provided, it acts as an infinite blocking loop to keep
+//     the application alive, as the main server runs in a background goroutine.
+//  2. If a command is provided, it replaces the special token "%PORT%" with
+//     the dynamically allocated server port, allowing backend workers to know
+//     where to connect. It redirects standard I/O to link the process directly
+//     to the user's terminal.
 func handleSubprocess(ctx context.Context, args ...string) error {
 	var err error
 	if len(args) == 0 {


### PR DESCRIPTION
This PR adds high-quality, non-obvious docstrings to `errors.go` and `main.go`. It clarifies the role of the centralized error handlers and explicitly details the hidden background and port-replacement mechanics within the `handleSubprocess` loop.

### Assumptions
*   The `bufsize` and `port` global variables function exactly as implied by their usage contexts, and `script` strictly serves as the target path.
*   Centralizing `ReportError` was done to pave the way for systems like Sentry, even if one is not wired up immediately.

### Alternatives Not Chosen
*   Did not add inline `//` comments inside function bodies, strictly adhering to the "Essentialism" constraint to favor high-level docstrings instead.

### How To Pivot
*   If the description of `handleSubprocess` is too verbose, it can be reduced to just stating it manages the lifecycle without detailing the `%PORT%` swap by removing the secondary bullet point.

### Next Knobs
*   `errors.go`: Wire up the actual Sentry implementation inside `ReportError`.
*   `main.go`: Add docstrings to `NewCGIHandler` or `ServeHTTP` to cover the remaining logic.

---
*PR created automatically by Jules for task [16428322770552851378](https://jules.google.com/task/16428322770552851378) started by @lucasew*