### PR TITLE
🧹 Janitor: Fix unhandled io return values and gracefully skip actionlint

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2024-03-24: Always handle return values from io functions like fmt.Fprint and Close() and pass errors to centralized logging.

--- a/main.go
+++ b/main.go
@@ -132,10 +132,16 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		ReportError(err, nil)
-		fmt.Fprint(w, err.Error())
+		if _, printErr := fmt.Fprint(w, err.Error()); printErr != nil {
+			ReportError(printErr, nil)
+		}
 		return
 	}
-	defer stdout.Close()
+	defer func() {
+		if err := stdout.Close(); err != nil {
+			ReportError(err, nil)
+		}
+	}()
 	defer func() {
 		if cmd.Process != nil {
 			err := cmd.Process.Kill()
@@ -151,7 +157,9 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ReportError(err, map[string]interface{}{"script": c.script})
 
 		// w.WriteHeader(500)
-		fmt.Fprint(w, err.Error())
+		if _, printErr := fmt.Fprint(w, err.Error()); printErr != nil {
+			ReportError(printErr, nil)
+		}
 		return
 	}
 	buf := make([]byte, bufsize)
@@ -166,13 +174,17 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			if err != nil {
 				ReportError(err, nil)
-				fmt.Fprint(w, err.Error())
+				if _, printErr := fmt.Fprint(w, err.Error()); printErr != nil {
+					ReportError(printErr, nil)
+				}
 				return
 			}
 			_, err = w.Write(buf[:sz])
 			if err != nil {
 				ReportError(err, nil)
-				fmt.Fprint(w, err.Error())
+				if _, printErr := fmt.Fprint(w, err.Error()); printErr != nil {
+					ReportError(printErr, nil)
+				}
 				return
 			}
 			if f, ok := w.(http.Flusher); ok {

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ run = "golangci-lint run"
 
 [tasks."lint:actionlint"]
 description = "Run actionlint"
-run = "actionlint"
+run = "if ls .github/workflows/*.yml >/dev/null 2>&1 || ls .github/workflows/*.yaml >/dev/null 2>&1; then actionlint; else echo 'No workflows found, skipping actionlint'; fi"
 
 [tasks."lint:ruff"]
 description = "Run ruff"


### PR DESCRIPTION
## What Changed
- Added error handling around `fmt.Fprint` and `stdout.Close()` calls in `main.go` that were previously unhandled.
- Updated the `actionlint` task in `mise.toml` to gracefully skip execution if no workflow files are found, using a correct shell `if` statement to avoid swallowing actual linter failures.
- Added a reusable insight pattern entry to `.jules/janitor.md` about always handling return values from IO functions.

## Why This Helps
- Prevents silent failures during IO operations, ensuring any unexpected write errors are properly caught and logged through the centralized `ReportError`.
- Fixes CI breakage on forks/branches where the `.github/workflows/` directory may be missing, while ensuring real linting errors are not ignored.

## Before/After
- **Before**: `fmt.Fprint(w, err.Error())` was called without checking its return value. `actionlint` task in `mise.toml` could either fail when workflows were missing or swallow actual linter errors depending on shell behavior.
- **After**: All IO writes capture their return values and call `ReportError` if an error occurs. The `actionlint` task correctly uses `if/then/else` to determine whether to run.

## Verification
- Ran `mise run fmt` to format Go code.
- Ran `mise run lint` successfully (`actionlint` cleanly skipped without errors since no workflows exist).
- Ran `mise run test` successfully.

---

### Assumptions
- The server does not explicitly need to change the HTTP response code (e.g., to 500) if `fmt.Fprint` fails writing the error, it only needs to log the fact that the write failed via `ReportError`.
- It's safe to use `> /dev/null 2>&1` in the `mise.toml` check because we just care if the files exist.

### Alternatives Not Chosen
- Modifying the HTTP response status with `w.WriteHeader(500)` before `fmt.Fprint` was not done as it was explicitly commented out (`// w.WriteHeader(500)`) in the original code, suggesting it might be an intentional design choice.

### How To Pivot
- If the `actionlint` task should instead be removed entirely or changed to use a Go-based tool, update `mise.toml` to remove the conditional shell logic entirely and delete `[tasks."lint:actionlint"]`.
- If `fmt.Fprint` errors should be fatal instead of just logged, change the new `ReportError(printErr, nil)` calls to `ReportFatal(printErr, nil)`.

### Next Knobs
- **`mise.toml`**: The `lint:actionlint` run command can be tweaked if the paths to the workflows change.
- **`.jules/janitor.md`**: New patterns can be appended here by future runs.

---
*PR created automatically by Jules for task [15253753159942827976](https://jules.google.com/task/15253753159942827976) started by @lucasew*