### PR TITLE
🧹 Janitor: Fix actionlint skip condition and unhandled returns

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2024-03-18: Gracefully skip actionlint in mise tasks when GitHub workflows are absent using shell conditionals, and explicitly handle fmt.Fprint return values.

--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		ReportError(err, nil)
-		fmt.Fprint(w, err.Error())
+		_, _ = fmt.Fprint(w, err.Error())
 		return
 	}
 	defer stdout.Close()
@@ -151,7 +151,7 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ReportError(err, map[string]interface{}{"script": c.script})
 
 		// w.WriteHeader(500)
-		fmt.Fprint(w, err.Error())
+		_, _ = fmt.Fprint(w, err.Error())
 		return
 	}
 	buf := make([]byte, bufsize)
@@ -166,13 +166,13 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			if err != nil {
 				ReportError(err, nil)
-				fmt.Fprint(w, err.Error())
+				_, _ = fmt.Fprint(w, err.Error())
 				return
 			}
 			_, err = w.Write(buf[:sz])
 			if err != nil {
 				ReportError(err, nil)
-				fmt.Fprint(w, err.Error())
+				_, _ = fmt.Fprint(w, err.Error())
 				return
 			}
 			if f, ok := w.(http.Flusher); ok {

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,13 @@ run = "golangci-lint run"
 
 [tasks."lint:actionlint"]
 description = "Run actionlint"
-run = "actionlint"
+run = """
+if ls .github/workflows/*.yml >/dev/null 2>&1 || ls .github/workflows/*.yaml >/dev/null 2>&1; then
+    actionlint
+else
+    echo "No workflow files found, skipping actionlint"
+fi
+"""
 
 [tasks."lint:ruff"]
 description = "Run ruff"


### PR DESCRIPTION
## What Changed
- Ignored return values from `fmt.Fprint` by assigning them to `_, _ =`.
- Adjusted the `lint:actionlint` task in `mise.toml` to gracefully skip if no `.github/workflows/*.yml` or `*.yaml` files are present.
- Created `.jules/janitor.md` with an insight log entry.

## Why This Helps
- Go linters and best practices require explicit handling of returns even from `fmt.Fprint`.
- `actionlint` fails aggressively when the workflows directory doesn't exist. This conditionally avoids a failing CI/Linting run for PRs that aren't modifying or don't have workflows present locally yet.

## Before/After
- `fmt.Fprint(w, err.Error())` -> `_, _ = fmt.Fprint(w, err.Error())`
- `mise.toml` actionlint task unconditionally ran `actionlint` -> conditionally skips `actionlint`

## Verification
- Ran `mise run lint`, confirmed all tasks pass cleanly.
- Ran `mise run test`.

### Assumptions
- Skipping `actionlint` completely when `.github/workflows` is empty or missing is acceptable compared to throwing an error.

### Alternatives Not Chosen
- Handling the return value by logging it using `ReportError`. It was not chosen since the previous intention was to just ignore it.

### How To Pivot
- If `actionlint` needs to always fail to indicate missing workflows, revert the `mise.toml` conditional block back to simply `run = "actionlint"`.

### Next Knobs
- `mise.toml`: Can adjust the shell conditional for `lint:actionlint` to be more strict or perform different operations.

---
*PR created automatically by Jules for task [11308164256553568816](https://jules.google.com/task/11308164256553568816) started by @lucasew*