### PR TITLE
🛠️ Refactor: Extract magic numbers and isolate error handling package

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2025-03-20: Unformatted code, including trailing whitespaces, will cause the `ciborg` CI check suite to fail silently with a generic 'Build failed' error. Ensure `gofmt` is run.

--- a/internal/apperror/errors.go
+++ b/internal/apperror/errors.go
@@ -1,4 +1,4 @@
-package main
+package apperror
 
 import (
 	"log"

--- a/main.go
+++ b/main.go
@@ -14,12 +14,19 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lucasew/ncgi/internal/apperror"
 	"github.com/phayes/freeport"
 )
 
 func init() {
 	_ = spew.Config
 }
+
+const (
+	defaultBufSize        = 64 * 1024
+	subprocessIdleDelay   = 1 * time.Second
+	subprocessWarmupDelay = 1 * time.Second
+)
 
 var bufsize int
 var script string
@@ -30,7 +37,7 @@ func main() {
 	defer cancel()
 	flag.StringVar(&script, "s", "./example", "script to be CGIed")
 	flag.IntVar(&port, "p", 0, "port to listen")
-	flag.IntVar(&bufsize, "b", 64*1024, "buffer size")
+	flag.IntVar(&bufsize, "b", defaultBufSize, "buffer size")
 	flag.Parse()
 	if port == 0 {
 		port = freeport.GetPort()
@@ -40,19 +47,19 @@ func main() {
 	defer func() {
 		err := server.Shutdown(ctx)
 		if err != nil {
-			ReportError(err, nil)
+			apperror.ReportError(err, nil)
 		}
 	}()
 	go func() {
 		err := server.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
-			ReportFatal(err, nil)
+			apperror.ReportFatal(err, nil)
 		}
 	}()
 
 	err := handleSubprocess(ctx, flag.Args()...)
 	if err != nil {
-		ReportFatal(err, nil)
+		apperror.ReportFatal(err, nil)
 	}
 }
 
@@ -60,7 +67,7 @@ func handleSubprocess(ctx context.Context, args ...string) error {
 	var err error
 	if len(args) == 0 {
 		for {
-			time.Sleep(1 * time.Second)
+			time.Sleep(subprocessIdleDelay)
 		}
 	}
 	args[0], err = exec.LookPath(args[0])
@@ -74,7 +81,7 @@ func handleSubprocess(ctx context.Context, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
-	time.Sleep(1 * time.Second)
+	time.Sleep(subprocessWarmupDelay)
 	return cmd.Run()
 }
 
@@ -85,11 +92,11 @@ type CGIHandler struct {
 func NewCGIHandler(script string) http.Handler {
 	p, err := exec.LookPath(script)
 	if err != nil {
-		ReportFatal(err, map[string]interface{}{"script": script})
+		apperror.ReportFatal(err, map[string]interface{}{"script": script})
 	}
 	p, err = filepath.Abs(p)
 	if err != nil {
-		ReportFatal(err, map[string]interface{}{"path": p})
+		apperror.ReportFatal(err, map[string]interface{}{"path": p})
 	}
 	log.Printf("Initializing CGI handler on folder '%s'...", p)
 	return CGIHandler{p}
@@ -131,7 +138,7 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cmd.Stdin = r.Body
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		ReportError(err, nil)
+		apperror.ReportError(err, nil)
 		fmt.Fprint(w, err.Error())
 		return
 	}
@@ -140,7 +147,7 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if cmd.Process != nil {
 			err := cmd.Process.Kill()
 			if err != nil {
-				ReportError(err, nil)
+				apperror.ReportError(err, nil)
 			}
 		}
 	}()
@@ -148,7 +155,7 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cmd.Stderr = os.Stderr
 	err = cmd.Start()
 	if err != nil {
-		ReportError(err, map[string]interface{}{"script": c.script})
+		apperror.ReportError(err, map[string]interface{}{"script": c.script})
 
 		// w.WriteHeader(500)
 		fmt.Fprint(w, err.Error())
@@ -165,13 +172,13 @@ func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if err != nil {
-				ReportError(err, nil)
+				apperror.ReportError(err, nil)
 				fmt.Fprint(w, err.Error())
 				return
 			}
 			_, err = w.Write(buf[:sz])
 			if err != nil {
-				ReportError(err, nil)
+				apperror.ReportError(err, nil)
 				fmt.Fprint(w, err.Error())
 				return
 			}


### PR DESCRIPTION
This PR addresses code smells and structural improvements while explicitly avoiding overlap with existing open PRs (#31, #32, #34, #35).

**Refactoring Performed:**
1. **Reduce Complexity:** Replaced magic numbers in `main.go` (`64*1024`, `1 * time.Second`) with appropriately named constants (`defaultBufSize`, `subprocessIdleDelay`, `subprocessWarmupDelay`). This reduces cognitive load as recommended in Robert C. Martin's *Clean Code*.
2. **Enhance Structure:** Relocated `errors.go` into a new `internal/apperror` package. This enforces the project's directory structure rules: grouping by domain and responsibility rather than by file type.

### Assumptions
- The delay of `1 * time.Second` used twice in `handleSubprocess` serves two distinct purposes: one for idle looping and one for warming up the subprocess before returning. They were extracted to separate constants to reflect these different semantics.
- `main.go` and `errors.go` are the only files affected by this relocation.

### Alternatives Not Chosen
- **Extracting CGI Logic:** I intentionally chose not to extract the `CGIHandler` methods (e.g., `ServeHTTP`), as open PRs (#31 and #35) are already actively working on streamlining and restructuring that specific logic. My goal was to avoid creating merge conflicts.
- **Fixing CI/actionlint:** I avoided touching `mise.toml` to fix the actionlint bug, as Janitor PRs (#34 and #36) are already attempting to fix it.

### How To Pivot
- If the domain package name `internal/apperror` is undesirable, it can be easily renamed (e.g., to `pkg/errors` or `internal/logger`) using a simple `mv` command and a global find/replace for the import path.
- If the constants should be configurable, they can be easily moved to be `flag` variables alongside `bufsize`.

### Next Knobs
- **Constant Values:** The values of `subprocessIdleDelay` and `subprocessWarmupDelay` can be tweaked directly in the `const` block at the top of `main.go`.
- **Package Location:** The `internal/apperror` directory can be moved or nested further depending on future architectural needs.

---
*PR created automatically by Jules for task [4293200660371420311](https://jules.google.com/task/4293200660371420311) started by @lucasew*