### PR TITLE
📝 Docs: Add docstrings to core components in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,10 @@ var bufsize int
 var script string
 var port int
 
+// main is the entry point of the ncgi application.
+// It initializes the command-line flags, sets up the HTTP server to listen on the specified (or randomly allocated) port,
+// binds the server to the CGI handler, and simultaneously starts the optional external subprocess.
+// It uses a context to manage graceful shutdown of both the server and the subprocess.
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -56,6 +60,10 @@ func main() {
 	}
 }
 
+// handleSubprocess manages an external command executing alongside the CGI handler.
+// It dynamically replaces the token "%PORT%" with the allocated server port to allow backend workers to connect.
+// If no command arguments are provided, it acts as an infinite blocking loop to keep the ncgi process alive.
+// It pipes standard I/O streams directly to the host and waits for the process to complete or the context to be canceled.
 func handleSubprocess(ctx context.Context, args ...string) error {
 	var err error
 	if len(args) == 0 {
@@ -78,10 +86,15 @@ func handleSubprocess(ctx context.Context, args ...string) error {
 	return cmd.Run()
 }
 
+// CGIHandler encapsulates the logic for executing a script as a Common Gateway Interface (CGI) program.
+// It stores the absolute path to the executable script.
 type CGIHandler struct {
 	script string
 }
 
+// NewCGIHandler validates the provided script path and initializes a new CGIHandler.
+// It resolves the absolute path of the script and reports a fatal error if the script cannot be found or resolved,
+// ensuring that the application fails fast during startup if misconfigured.
 func NewCGIHandler(script string) http.Handler {
 	p, err := exec.LookPath(script)
 	if err != nil {
@@ -95,6 +108,10 @@ func NewCGIHandler(script string) http.Handler {
 	return CGIHandler{p}
 }
 
+// ServeHTTP implements the http.Handler interface by executing the underlying CGI script on each incoming HTTP request.
+// It maps standard HTTP concepts (method, URI, headers, query parameters) into POSIX CGI environment variables.
+// It also streams the request body to the script's standard input and streams the script's standard output back to the HTTP client.
+// The function manages the lifecycle of the subprocess, ensuring it is killed if the request context is canceled or when the response finishes.
 func (c CGIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	cmd := exec.Cmd{}


### PR DESCRIPTION
### Description

This Pull Request addresses the lack of documentation in the core CGI server components. It adds detailed docstrings to `main.go` for the following functions and types:

- `main()`: Explains the application entry point, flag initialization, server setup, and graceful shutdown.
- `handleSubprocess()`: Details the management of the external command, dynamic port substitution, and infinite blocking loop behavior.
- `CGIHandler` struct: Describes its purpose as an encapsulation for executing CGI scripts.
- `NewCGIHandler()`: Outlines the script path validation and initialization process.
- `ServeHTTP()`: Explains the mapping of HTTP concepts to POSIX CGI environment variables, IO streaming, and subprocess lifecycle management.

### Assumptions
- The documentation format should strictly adhere to Go's standard single-line comment format (`//`) for declarations, despite the prompt's general suggestion of `/** ... */` which is more common in JS/TS.
- No executable logic was modified, ensuring zero regressions or changes to runtime behavior.

### Alternatives Not Chosen
- Adding inline comments (`//`) inside function bodies was avoided as per the `Essentialism` and `Value-Driven` directives to focus only on non-obvious details at the declaration level.
- Scattering documentation across multiple files was avoided to strictly adhere to the `ONE cohesive area per PR` directive.

### How To Pivot
- If the documentation needs to be adjusted or expanded to cover other files (e.g., `errors.go`), the current changes can be reverted using `git revert`, and a new branch can be created to target the newly identified areas.

### Next Knobs
- **Files:** The `errors.go` file currently has minimal documentation and could be the target for a future docs PR.
- **Flags:** The specific phrasing or detail level in the added docstrings can be modified in subsequent commits if deemed too verbose or lacking in certain areas.

---
*PR created automatically by Jules for task [14393489670020254889](https://jules.google.com/task/14393489670020254889) started by @lucasew*